### PR TITLE
Fix for filter_input parameter issue

### DIFF
--- a/includes/iworks/pwa/class-iworks-pwa-administrator.php
+++ b/includes/iworks/pwa/class-iworks-pwa-administrator.php
@@ -458,7 +458,7 @@ jQuery( function( $ ) {
 		 * @since 1.5.8
 		 */
 		if ( isset( $_GET['_wpnonce'] ) ) {
-			if ( wp_verify_nonce( filter_input( 'INPUT_GET', '_wpnonce' ), 'iworks-pwa-viewport' ) ) {
+			if ( wp_verify_nonce( filter_input( INPUT_GET, '_wpnonce' ), 'iworks-pwa-viewport' ) ) {
 				return;
 			}
 		}


### PR DESCRIPTION
This should address issue #17 

Changes filter_input call to use `INPUT_GET` as a constant (which resolves to the appropriate int) rather than a string